### PR TITLE
chore: update minimum Node version to 20 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The LaunchDarkly OpenFeature provider for the Server-Side SDK for Node.js is des
 
 ## Supported Node versions
 
-This sample is compatible with Node.js versions 18 and above.
+This sample is compatible with Node.js versions 20 and above.
 
 ## Build instructions
 


### PR DESCRIPTION
## Summary

Updates the README's "Supported Node versions" section from Node 18+ to Node 20+, matching the requirement introduced in `@launchdarkly/openfeature-node-server` v1.2.0 which dropped Node 18 support.

Both SDK dependencies already resolve to their latest versions (`@launchdarkly/openfeature-node-server@1.2.0`, `@launchdarkly/node-server-sdk@9.11.2`) within the existing constraints. No code changes or deprecated API usage found.

Link to Devin session: https://app.devin.ai/sessions/50c88d578dfc4b7e8f5c40e67de51e19
Requested by: @kinyoklion