### PR TITLE
chore: update SDK dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@launchdarkly/openfeature-node-server": ">= 1.0.0",
-    "@openfeature/server-sdk": "^1.14.0",
-    "@launchdarkly/node-server-sdk": ">= 9.4.5"
+    "@launchdarkly/openfeature-node-server": ">= 1.2.0",
+    "@openfeature/server-sdk": "^1.22.0",
+    "@launchdarkly/node-server-sdk": ">= 9.11.3"
   }
 }


### PR DESCRIPTION
## Summary

Update LaunchDarkly SDK dependency version constraints to latest stable releases:

- `@launchdarkly/openfeature-node-server`: `>= 1.0.0` → `>= 1.2.0`
- `@launchdarkly/node-server-sdk`: `>= 9.4.5` → `>= 9.11.3`
- `@openfeature/server-sdk`: `^1.14.0` → `^1.22.0`

No deprecated APIs found in the example code. App tested successfully with the updated dependencies.

Link to Devin session: https://app.devin.ai/sessions/af8b24f19d3b4a25940434c40417a28b
Requested by: @kinyoklion